### PR TITLE
Fix #13: is broken

### DIFF
--- a/admin/src/components/SnippetView/SnippetItem.vue
+++ b/admin/src/components/SnippetView/SnippetItem.vue
@@ -48,7 +48,7 @@ export default {
       <div class="col col-10 list-group-item-snippet">
         <div class="row">
           <div class="col col-1"><code-badge :type="snippet.type" /></div>
-          <div class="col col-4">{{snippet.name}}</div>
+          <div class="col col-4 snippet-name" @click="onShowClick()">{{snippet.name}}</div>
           <div class="col col-5 text-body-tertiary">{{snippet.description}}</div>
         </div>
       </div>
@@ -88,6 +88,11 @@ export default {
     align-items: center;
     font-size: x-large;
     background-color: #0f2537;
+  }
+
+  .snippet-name {
+    cursor: pointer;
+    color: #0d6efd;
   }
 }
 </style>


### PR DESCRIPTION
## DE

### Problem
Snippet name should be clickable to navigate to detail page, but currently only the "btn btn-sm btn-info" button works for navigation

### Diagnose
In SnippetItem.vue, the snippet name is displayed as plain text in a div element without click functionality. Only the blue info button (btn btn-sm btn-info) with onShowClick() method navigates to SnippetDetail page. The issue description requests that clicking the snippet name should also navigate to the detail page.

### Fixplan
- Add click event handler to the snippet name element
- Modify the template to make snippet name clickable (cursor pointer style)
- Reuse existing onShowClick() method for consistency

### Verifikation
- Verify snippet name renders as clickable element
- Test that clicking snippet name navigates to SnippetDetail page with correct ID
- Ensure existing blue info button functionality remains intact
- Check visual styling shows name is clickable (cursor pointer)

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: nein
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 7
- Geaenderte Dateien: admin/src/components/SnippetView/SnippetItem.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-13/artefacts-20260603-090313`

## EN

### Problem
Snippet name should be clickable to navigate to detail page, but currently only the "btn btn-sm btn-info" button works for navigation

### Diagnosis
In SnippetItem.vue, the snippet name is displayed as plain text in a div element without click functionality. Only the blue info button (btn btn-sm btn-info) with onShowClick() method navigates to SnippetDetail page. The issue description requests that clicking the snippet name should also navigate to the detail page.

### Fix Plan
- Add click event handler to the snippet name element
- Modify the template to make snippet name clickable (cursor pointer style)
- Reuse existing onShowClick() method for consistency

### Verification
- Verify snippet name renders as clickable element
- Test that clicking snippet name navigates to SnippetDetail page with correct ID
- Ensure existing blue info button functionality remains intact
- Check visual styling shows name is clickable (cursor pointer)

- Local checks: green
- Pipeline code-review clearance: no
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 7
- Changed files: admin/src/components/SnippetView/SnippetItem.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-13/artefacts-20260603-090313`

Closes #13
