### PR TITLE
Fix #17: Add link to detail

### DIFF
--- a/admin/src/components/NoteView/NoteItem.vue
+++ b/admin/src/components/NoteView/NoteItem.vue
@@ -43,7 +43,9 @@ export default {
 
       <div class="col col-10">
         <div class="row">
-          <div class="col col-4">{{ note.name }}</div>
+          <div class="col col-4">
+            <button class="btn btn-link p-0 text-start" @click="onShowClick()">{{ note.name }}</button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## DE

### Problem
Issue requests adding clickable navigation links on note names in the notes listing (/notes) to redirect to the detail view (/note/detail/:id). The NoteItem.vue component at line 46 needs modification to make note names clickable.

### Diagnose
Issue description points to admin/src/components/NoteView/NoteItem.vue:46 where note names should be clickable. Router shows NoteDetail route exists at /note/detail/:id. Current NoteItem component only has edit/delete/show buttons but note name (line 46: {{ note.name }}) is not clickable. Navigation method onShowClick() already exists and correctly routes to NoteDetail.

### Fixplan
- Make the note name clickable by wrapping it in a button or adding a click handler
- Reuse the existing onShowClick() method which already navigates to NoteDetail with correct params
- Ensure consistent styling with the rest of the UI

### Verifikation
- Build the admin application to verify no syntax errors
- Test that clicking note names in /notes listing navigates to /note/detail/:id
- Verify existing edit/delete/show buttons still work correctly
- Run unit tests to ensure no regressions

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 4
- Geaenderte Dateien: admin/src/components/NoteView/NoteItem.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-17/artefacts-20260605-061739`

## EN

### Problem
Issue requests adding clickable navigation links on note names in the notes listing (/notes) to redirect to the detail view (/note/detail/:id). The NoteItem.vue component at line 46 needs modification to make note names clickable.

### Diagnosis
Issue description points to admin/src/components/NoteView/NoteItem.vue:46 where note names should be clickable. Router shows NoteDetail route exists at /note/detail/:id. Current NoteItem component only has edit/delete/show buttons but note name (line 46: {{ note.name }}) is not clickable. Navigation method onShowClick() already exists and correctly routes to NoteDetail.

### Fix Plan
- Make the note name clickable by wrapping it in a button or adding a click handler
- Reuse the existing onShowClick() method which already navigates to NoteDetail with correct params
- Ensure consistent styling with the rest of the UI

### Verification
- Build the admin application to verify no syntax errors
- Test that clicking note names in /notes listing navigates to /note/detail/:id
- Verify existing edit/delete/show buttons still work correctly
- Run unit tests to ensure no regressions

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 4
- Changed files: admin/src/components/NoteView/NoteItem.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-17/artefacts-20260605-061739`

Closes #17
