### PR TITLE
Fix #28: Preserve task status when editing tasks

### DIFF
--- a/admin/src/views/Task/TaskForm.vue
+++ b/admin/src/views/Task/TaskForm.vue
@@ -38,7 +38,10 @@ export default {
     },
 
     onSave() {
-      this.task.status = 'open'
+      // Only set default status for new tasks
+      if (!this.task.id) {
+        this.task.status = 'open'
+      }
 
       this.$taskRepository
         .saveTask(this.task)


### PR DESCRIPTION
## DE

### Problem
Issue #28 has an existing PR #37 that implements the fix for preserving task status during edits. The PR correctly adds conditional logic to only set default 'open' status for new tasks while preserving existing status during updates.

### Diagnose
TaskForm.vue onSave() method unconditionally sets 'this.task.status = open' for both new and existing tasks. The existing PR #37 shows the fix: conditional check 'if (!this.task.id)' to only set default status for new tasks. Repository context confirms task status validation supports 'open', 'inProgress', 'inReview', 'completed' statuses.

### Fixplan
- The fix is already implemented in PR #37
- Modified onSave() method in TaskForm.vue to check if task has existing ID
- Only set default status 'open' for new tasks (!this.task.id)
- Preserve existing status for tasks that already have an ID

### Verifikation
- Create a test task and set its status to 'completed'
- Edit task properties (name, description, priority, due date) without changing status
- Save the task and verify status remains 'completed'
- Create a new task and verify it defaults to 'open' status
- Run frontend tests to ensure no regression

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a frontend Vue.js component fix. The existing codebase shows no frontend unit tests for this component, and the issue is best verified through manual testing or E2E tests.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 5
- Geaenderte Dateien: admin/src/views/Task/TaskForm.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-28/artefacts-20260608-125422`

## EN

### Problem
Issue #28 has an existing PR #37 that implements the fix for preserving task status during edits. The PR correctly adds conditional logic to only set default 'open' status for new tasks while preserving existing status during updates.

### Diagnosis
TaskForm.vue onSave() method unconditionally sets 'this.task.status = open' for both new and existing tasks. The existing PR #37 shows the fix: conditional check 'if (!this.task.id)' to only set default status for new tasks. Repository context confirms task status validation supports 'open', 'inProgress', 'inReview', 'completed' statuses.

### Fix Plan
- The fix is already implemented in PR #37
- Modified onSave() method in TaskForm.vue to check if task has existing ID
- Only set default status 'open' for new tasks (!this.task.id)
- Preserve existing status for tasks that already have an ID

### Verification
- Create a test task and set its status to 'completed'
- Edit task properties (name, description, priority, due date) without changing status
- Save the task and verify status remains 'completed'
- Create a new task and verify it defaults to 'open' status
- Run frontend tests to ensure no regression

### Test Coverage
- Test included: no
- Reason: This is a frontend Vue.js component fix. The existing codebase shows no frontend unit tests for this component, and the issue is best verified through manual testing or E2E tests.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 5
- Changed files: admin/src/views/Task/TaskForm.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-28/artefacts-20260608-125422`

Closes #28
