### PR TITLE
Fix #30: Show actual task load errors on detail page

### DIFF
--- a/admin/src/views/Task/TaskDetail.vue
+++ b/admin/src/views/Task/TaskDetail.vue
@@ -35,9 +35,7 @@ export default {
       })
       .catch((error) => {
         this.$mainStore.addStickyMessage(
-          'error',
-          `Could not load task with ID: ${this.task.id}.`,
-          error,
+          new Message('Error', `Failed to load task with id: ${this.$route.params.id}`, error),
         )
       })
   },


### PR DESCRIPTION
## DE

### Problem
Issue #30 reports incorrect error handling in TaskDetail.vue. Existing PR #39 already contains a fix using new Message() constructor with route params ID. The fix is complete and needs verification.

### Diagnose
TaskDetail.vue catch block already fixed in PR #39 - uses new Message() constructor with this.$route.params.id instead of this.task.id. Code matches patterns from NoteDetail.vue and SnippetDetail.vue.

### Fixplan
- Fix is already implemented in existing PR #39
- TaskDetail.vue lines 31-36 show correct new Message() usage
- Error message uses this.$route.params.id instead of this.task.id
- Implementation follows established pattern from other detail views

### Verifikation
- Run npm ci in admin directory
- Run npm run build to verify syntax
- Run npm run test:unit to ensure no regressions
- Test manually with invalid task ID to confirm error display

### Testabdeckung
- Test enthalten: nein
- Begruendung: No useful automated test possible for UI error handling scenario. Testing error message display requires manual verification in browser with invalid task IDs.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 4
- Geaenderte Dateien: admin/src/views/Task/TaskDetail.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-30/artefacts-20260608-125639`

## EN

### Problem
Issue #30 reports incorrect error handling in TaskDetail.vue. Existing PR #39 already contains a fix using new Message() constructor with route params ID. The fix is complete and needs verification.

### Diagnosis
TaskDetail.vue catch block already fixed in PR #39 - uses new Message() constructor with this.$route.params.id instead of this.task.id. Code matches patterns from NoteDetail.vue and SnippetDetail.vue.

### Fix Plan
- Fix is already implemented in existing PR #39
- TaskDetail.vue lines 31-36 show correct new Message() usage
- Error message uses this.$route.params.id instead of this.task.id
- Implementation follows established pattern from other detail views

### Verification
- Run npm ci in admin directory
- Run npm run build to verify syntax
- Run npm run test:unit to ensure no regressions
- Test manually with invalid task ID to confirm error display

### Test Coverage
- Test included: no
- Reason: No useful automated test possible for UI error handling scenario. Testing error message display requires manual verification in browser with invalid task IDs.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 4
- Changed files: admin/src/views/Task/TaskDetail.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-30/artefacts-20260608-125639`

Closes #30
