### PR TITLE
Fix #34: Pass snippet language to code block on detail page

### DIFF
--- a/admin/src/views/Snippet/SnippetDetail.vue
+++ b/admin/src/views/Snippet/SnippetDetail.vue
@@ -101,7 +101,7 @@ export default {
       <span class="badge bg-secondary me-1">{{ category.name }}</span>
       <code-badge :type="snippet.type" />
     </div>
-    <code-block :code="snippet.code" />
+    <code-block :code="snippet.code" :lang="snippet.type" />
   </content-container>
 
   <base-modal :open="isDeleteConfirmModalOpen" @close="closeDeleteModal">


### PR DESCRIPTION
## DE

### Problem
Issue reports that SnippetDetail.vue doesn't pass the lang prop to CodeBlock component, causing all snippets to use default PHP highlighting instead of their actual language type. The fix requires adding :lang="snippet.type" to the code-block component in SnippetDetail.vue.

### Diagnose
Clear evidence from repository context shows SnippetForm.vue correctly passes :lang="snippet.type" to code-block component, while SnippetDetail.vue only passes :code="snippet.code" without the lang prop. CodeBlock.vue defaults to 'php' when lang prop is not provided.

### Fixplan
- Add the missing :lang="snippet.type" prop to the code-block component in SnippetDetail.vue
- Ensure consistency between SnippetForm.vue preview and SnippetDetail.vue display

### Verifikation
- Build the admin application to ensure no compilation errors
- Run unit tests to verify no regressions
- Manually test with different snippet types (JavaScript, SQL, etc.) to confirm proper syntax highlighting

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 2
- Geaenderte Dateien: admin/src/views/Snippet/SnippetDetail.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-34/artefacts-20260605-071552`

## EN

### Problem
Issue reports that SnippetDetail.vue doesn't pass the lang prop to CodeBlock component, causing all snippets to use default PHP highlighting instead of their actual language type. The fix requires adding :lang="snippet.type" to the code-block component in SnippetDetail.vue.

### Diagnosis
Clear evidence from repository context shows SnippetForm.vue correctly passes :lang="snippet.type" to code-block component, while SnippetDetail.vue only passes :code="snippet.code" without the lang prop. CodeBlock.vue defaults to 'php' when lang prop is not provided.

### Fix Plan
- Add the missing :lang="snippet.type" prop to the code-block component in SnippetDetail.vue
- Ensure consistency between SnippetForm.vue preview and SnippetDetail.vue display

### Verification
- Build the admin application to ensure no compilation errors
- Run unit tests to verify no regressions
- Manually test with different snippet types (JavaScript, SQL, etc.) to confirm proper syntax highlighting

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 2
- Changed files: admin/src/views/Snippet/SnippetDetail.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-34/artefacts-20260605-071552`

Closes #34
