### PR TITLE
Fix #30: Show actual task load errors on detail page

### DIFF
--- a/admin/src/views/Task/TaskDetail.vue
+++ b/admin/src/views/Task/TaskDetail.vue
@@ -35,9 +35,7 @@ export default {
       })
       .catch((error) => {
         this.$mainStore.addStickyMessage(
-          'error',
-          `Could not load task with ID: ${this.task.id}.`,
-          error,
+          new Message('Error', `Could not load task with ID: ${this.$route.params.id}.`, error)
         )
       })
   },


### PR DESCRIPTION
## DE

### Problem
The TaskDetail.vue component incorrectly calls addStickyMessage with wrong argument format. The store expects a Message instance but receives raw string parameters, causing the actual error to be hidden behind a generic store error message.

### Diagnose
TaskDetail.vue line 38-42 calls addStickyMessage with string parameters instead of Message instance. Other components (NoteDetail, SnippetDetail, etc.) correctly use 'new Message(...)' pattern. The issue also affects error message content by using this.task.id instead of route parameter.

### Fixplan
- Fix the addStickyMessage call in TaskDetail.vue catch block to use 'new Message(...)'
- Replace this.task.id with this.$route.params.id for more reliable error messaging
- Ensure the error parameter is properly passed as the third argument to Message constructor

### Verifikation
- Navigate to task detail page with invalid ID to trigger error
- Verify that actual error message is displayed instead of generic store message
- Confirm error message uses route ID instead of empty task.id
- Run admin build and tests to ensure no regressions

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a UI error handling fix that requires manual interaction to trigger. Unit tests would require mocking repository failures which is better tested through integration or manual testing.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 4
- Geaenderte Dateien: admin/src/views/Task/TaskDetail.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-30/artefacts-20260608-132048`

## EN

### Problem
The TaskDetail.vue component incorrectly calls addStickyMessage with wrong argument format. The store expects a Message instance but receives raw string parameters, causing the actual error to be hidden behind a generic store error message.

### Diagnosis
TaskDetail.vue line 38-42 calls addStickyMessage with string parameters instead of Message instance. Other components (NoteDetail, SnippetDetail, etc.) correctly use 'new Message(...)' pattern. The issue also affects error message content by using this.task.id instead of route parameter.

### Fix Plan
- Fix the addStickyMessage call in TaskDetail.vue catch block to use 'new Message(...)'
- Replace this.task.id with this.$route.params.id for more reliable error messaging
- Ensure the error parameter is properly passed as the third argument to Message constructor

### Verification
- Navigate to task detail page with invalid ID to trigger error
- Verify that actual error message is displayed instead of generic store message
- Confirm error message uses route ID instead of empty task.id
- Run admin build and tests to ensure no regressions

### Test Coverage
- Test included: no
- Reason: This is a UI error handling fix that requires manual interaction to trigger. Unit tests would require mocking repository failures which is better tested through integration or manual testing.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 4
- Changed files: admin/src/views/Task/TaskDetail.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-30/artefacts-20260608-132048`

Closes #30
