### PR TITLE
Fix #28: Preserve task status when editing tasks

### DIFF
--- a/admin/src/views/Task/TaskForm.vue
+++ b/admin/src/views/Task/TaskForm.vue
@@ -38,7 +38,10 @@ export default {
     },
 
     onSave() {
-      this.task.status = 'open'
+      // Only set default status for new tasks, preserve existing status for updates
+      if (!this.task.id) {
+        this.task.status = 'open'
+      }
 
       this.$taskRepository
         .saveTask(this.task)


### PR DESCRIPTION
## DE

### Problem
Issue describes unconditional status reset to 'open' in TaskForm.vue onSave() method. Multiple comments reference existing PR #37, but no existing pull request is provided in context.

### Diagnose
TaskForm.vue line 41 shows 'this.task.status = open' set unconditionally in onSave() method before every save operation. Issue clearly describes impact on existing tasks losing their status when edited.

### Fixplan
- Modify TaskForm.vue onSave() method to only set default status for new tasks
- Add conditional check using !this.task.id to identify new vs existing tasks
- Preserve existing task status when editing existing tasks
- Ensure new tasks still get appropriate default status

### Verifikation
- Run admin npm build and unit tests to ensure no regressions
- Manually test creating new task defaults to 'open' status
- Manually test editing existing task with 'completed' status preserves status
- Verify task form continues to work for both create and update scenarios

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a frontend Vue.js component issue without existing test infrastructure for Vue components in the repository. Manual testing through the admin interface is the appropriate verification method.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 5
- Geaenderte Dateien: admin/src/views/Task/TaskForm.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-28/artefacts-20260608-135420`

## EN

### Problem
Issue describes unconditional status reset to 'open' in TaskForm.vue onSave() method. Multiple comments reference existing PR #37, but no existing pull request is provided in context.

### Diagnosis
TaskForm.vue line 41 shows 'this.task.status = open' set unconditionally in onSave() method before every save operation. Issue clearly describes impact on existing tasks losing their status when edited.

### Fix Plan
- Modify TaskForm.vue onSave() method to only set default status for new tasks
- Add conditional check using !this.task.id to identify new vs existing tasks
- Preserve existing task status when editing existing tasks
- Ensure new tasks still get appropriate default status

### Verification
- Run admin npm build and unit tests to ensure no regressions
- Manually test creating new task defaults to 'open' status
- Manually test editing existing task with 'completed' status preserves status
- Verify task form continues to work for both create and update scenarios

### Test Coverage
- Test included: no
- Reason: This is a frontend Vue.js component issue without existing test infrastructure for Vue components in the repository. Manual testing through the admin interface is the appropriate verification method.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 5
- Changed files: admin/src/views/Task/TaskForm.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-28/artefacts-20260608-135420`

Closes #28
