### PR TITLE
Fix #29: Initialize accordion state before writing store values

### DIFF
--- a/admin/src/stores/MainStore.js
+++ b/admin/src/stores/MainStore.js
@@ -15,7 +15,7 @@ export const useMainStore = defineStore('mainStore', {
     /**
      * @type Object
      */
-    accordionStates: null,
+    accordionStates: {},
 
     /**
      * @type {Message[]}
@@ -104,6 +104,10 @@ export const useMainStore = defineStore('mainStore', {
     },
 
     setAccordionState(type, id, isOpen) {
+      if (!this.accordionStates) {
+        this.accordionStates = {}
+      }
+
       if (!this.accordionStates[type]) {
         this.accordionStates[type] = {}
       }


### PR DESCRIPTION
## DE

### Problem
Accordion state initialization issue causing null reference errors when clicking accordion headers before async state loading completes. Historical PR #38 mentioned in comments but no existing PR provided.

### Diagnose
MainStore initializes accordionStates to null, but setAccordionState method directly accesses this.accordionStates[type] without null check. Multiple Vue components call setAccordionState when users click accordion headers, causing 'Cannot read properties of null' errors if loading fails or user clicks before async load completes.

### Fixplan
- Initialize accordionStates to empty object {} instead of null in MainStore state
- Add defensive null check in setAccordionState method before accessing accordionStates[type]
- Ensure initAccordionStates properly handles both successful loads and fallback scenarios

### Verifikation
- Run npm ci and npm run build in admin directory to verify no build errors
- Test manual accordion clicking before page load completes
- Verify accordion state persists correctly after successful backend load
- Check browser console shows no null reference errors during accordion interactions

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a frontend UI interaction issue that would require complex Vue component testing with async state mocking. Manual testing through browser interaction is more appropriate for this accordion UI behavior.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 6
- Geaenderte Dateien: admin/src/stores/MainStore.js

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-29/artefacts-20260608-135707`

## EN

### Problem
Accordion state initialization issue causing null reference errors when clicking accordion headers before async state loading completes. Historical PR #38 mentioned in comments but no existing PR provided.

### Diagnosis
MainStore initializes accordionStates to null, but setAccordionState method directly accesses this.accordionStates[type] without null check. Multiple Vue components call setAccordionState when users click accordion headers, causing 'Cannot read properties of null' errors if loading fails or user clicks before async load completes.

### Fix Plan
- Initialize accordionStates to empty object {} instead of null in MainStore state
- Add defensive null check in setAccordionState method before accessing accordionStates[type]
- Ensure initAccordionStates properly handles both successful loads and fallback scenarios

### Verification
- Run npm ci and npm run build in admin directory to verify no build errors
- Test manual accordion clicking before page load completes
- Verify accordion state persists correctly after successful backend load
- Check browser console shows no null reference errors during accordion interactions

### Test Coverage
- Test included: no
- Reason: This is a frontend UI interaction issue that would require complex Vue component testing with async state mocking. Manual testing through browser interaction is more appropriate for this accordion UI behavior.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 6
- Changed files: admin/src/stores/MainStore.js

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-29/artefacts-20260608-135707`

Closes #29
