### PR TITLE
Fix #30: Show actual task load errors on detail page

### DIFF
--- a/admin/src/views/Task/TaskDetail.vue
+++ b/admin/src/views/Task/TaskDetail.vue
@@ -35,9 +35,7 @@ export default {
       })
       .catch((error) => {
         this.$mainStore.addStickyMessage(
-          'error',
-          `Could not load task with ID: ${this.task.id}.`,
-          error,
+          new Message('Error', `Could not load task with ID: ${this.$route.params.id}.`, error)
         )
       })
   },


### PR DESCRIPTION
## DE

### Problem
TaskDetail.vue error handling incorrectly calls store with wrong parameter type instead of Message instance, hiding actual load errors

### Diagnose
Issue confirmed in admin/src/views/Task/TaskDetail.vue line 33-37. Error handler calls addStickyMessage with raw parameters instead of Message instance, and uses this.task.id which may be undefined during load failure. Other views (NoteDetail.vue, SnippetDetail.vue) correctly use new Message(...) pattern.

### Fixplan
- Fix TaskDetail.vue catch block to use new Message() constructor
- Replace this.task.id with this.$route.params.id for stable ID reference
- Ensure error context is properly passed to Message constructor

### Verifikation
- Test task detail page with non-existent task ID
- Verify actual error message is displayed instead of generic store error
- Confirm error message contains route ID instead of empty task ID
- Check that error context is properly shown

### Testabdeckung
- Test enthalten: nein
- Begruendung: This is a UI error handling fix that requires manual testing with invalid task IDs. No meaningful unit test can verify the visual error message display behavior.
- Testdateien: [keine]

- Lokale Checks: gruen
- Pipeline-Code-Review-Freigabe: ja
- Pipeline-Reruns: 0

### Diff
- Produktive Dateien: 1
- Produktive Zeilen: 4
- Geaenderte Dateien: admin/src/views/Task/TaskDetail.vue

Run-Artefakte: `/home/dennis/www/AIFixAutomation/var/runs/issue-30/artefacts-20260608-135937`

## EN

### Problem
TaskDetail.vue error handling incorrectly calls store with wrong parameter type instead of Message instance, hiding actual load errors

### Diagnosis
Issue confirmed in admin/src/views/Task/TaskDetail.vue line 33-37. Error handler calls addStickyMessage with raw parameters instead of Message instance, and uses this.task.id which may be undefined during load failure. Other views (NoteDetail.vue, SnippetDetail.vue) correctly use new Message(...) pattern.

### Fix Plan
- Fix TaskDetail.vue catch block to use new Message() constructor
- Replace this.task.id with this.$route.params.id for stable ID reference
- Ensure error context is properly passed to Message constructor

### Verification
- Test task detail page with non-existent task ID
- Verify actual error message is displayed instead of generic store error
- Confirm error message contains route ID instead of empty task ID
- Check that error context is properly shown

### Test Coverage
- Test included: no
- Reason: This is a UI error handling fix that requires manual testing with invalid task IDs. No meaningful unit test can verify the visual error message display behavior.
- Test files: [none]

- Local checks: green
- Pipeline code-review clearance: yes
- Pipeline reruns: 0

### Diff
- Productive files: 1
- Productive lines: 4
- Changed files: admin/src/views/Task/TaskDetail.vue

Run artifacts: `/home/dennis/www/AIFixAutomation/var/runs/issue-30/artefacts-20260608-135937`

Closes #30
